### PR TITLE
pull request for gnome-shell-extension-duolingo-status

### DIFF
--- a/dateUtils.js
+++ b/dateUtils.js
@@ -1,7 +1,0 @@
-function isToday(date) {
-	let today = new Date(new Date().getTime() - 4 * 60 * 60 * 1000);
-	let current_day = today.getUTCDate();
-	let current_month = today.getUTCMonth();
-	let current_year = today.getUTCFullYear();
-	return date.getUTCDate() == current_day && date.getUTCMonth() == current_month && date.getUTCFullYear() == current_year;
-}

--- a/dateUtils.js
+++ b/dateUtils.js
@@ -1,7 +1,7 @@
 function isToday(date) {
-	let today = new Date();
-	let current_day = today.getDate();
-	let current_month = today.getMonth();
-	let current_year = today.getFullYear();
-	return date.getDate() == current_day && date.getMonth() == current_month && date.getFullYear() == current_year;
+	let today = new Date(new Date().getTime() - 4 * 60 * 60 * 1000);
+	let current_day = today.getUTCDate();
+	let current_month = today.getUTCMonth();
+	let current_year = today.getUTCFullYear();
+	return date.getUTCDate() == current_day && date.getUTCMonth() == current_month && date.getUTCFullYear() == current_year;
 }

--- a/duolingo.js
+++ b/duolingo.js
@@ -22,7 +22,7 @@ const Duolingo = new Lang.Class({
 			return;
 		}		
 		
-		let url = 'http://duolingo.com/users/' + this.login;
+		let url = 'https://duolingo.com/users/' + this.login;
 		let request = Soup.Message.new('GET', url);
 		let session = new Soup.SessionSync();
 		session.queue_message(request, Lang.bind(this, function(session, response) {
@@ -41,7 +41,7 @@ const Duolingo = new Lang.Class({
 	},
 	
 	/** Returns the sum of improvements for the given date */
-	get_improvement: function(date) {
+	get_improvement: function(now) {
 		let improvements = this.raw_data.calendar;
 		let sum = 0;
 		for (let i in improvements) {

--- a/duolingo.js
+++ b/duolingo.js
@@ -3,7 +3,8 @@ const Soup = imports.gi.Soup;
 const Main = imports.ui.main;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const DateUtils = Me.imports.dateUtils;
+const TimeZone = imports.gi.GLib.TimeZone;
+const DateTime = imports.gi.GLib.DateTime;
 
 const Duolingo = new Lang.Class({
 	Name: 'Duolingo',
@@ -40,13 +41,24 @@ const Duolingo = new Lang.Class({
 		}));
 	},
 	
+	get_duolingos_daystart : function() {
+		let tz = TimeZone.new("America/New_York");
+		let now = DateTime.new_now(tz);
+		let year = now.get_year();
+		let month = now.get_month();
+		let day = now.get_day_of_month();
+		let day_start = DateTime.new(tz, year, month, day, 0, 0, 0.0);
+		return day_start.to_utc().to_unix() * 1000;
+	},
+
 	/** Returns the sum of improvements for the given date */
-	get_improvement: function(now) {
+	get_improvement: function() {
+		let take_after = this.get_duolingos_daystart();
 		let improvements = this.raw_data.calendar;
 		let sum = 0;
 		for (let i in improvements) {
-			let date = new Date(improvements[i].datetime);
-			if (DateUtils.isToday(date)) {
+			let date = improvements[i].datetime;
+			if (take_after < date) {
 				sum += parseInt(improvements[i].improvement);
 			}
 		}

--- a/extension.js
+++ b/extension.js
@@ -15,6 +15,7 @@ const Util = imports.misc.util;
 const FLAGS = Me.imports.flagsKeys.flags;
 const Utils = Me.imports.utils;
 const Settings = Convenience.getSettings();
+const GLib = imports.gi.GLib;
 
 let icon_size = 16;
 let menu_width = 250;
@@ -84,8 +85,7 @@ const DuolingoMenuButton = new Lang.Class({
 		this.profile_menu.actor.add(streak_label, {expand: true});
 		
 		this.menu.addMenuItem(this.profile_menu);
-		let today = new Date();
-		let improvement = this.duolingo.get_improvement(today);
+		let improvement = this.duolingo.get_improvement();
 		let daily_goal = this.duolingo.get_daily_goal();
 		this._set_todays_improvement(improvement, daily_goal);
 				

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 	"name": "Duolingo Status", 
-	"shell-version": ["3.16.3"], 
+	"shell-version": ["3.16.3", "3.18"],
 	"description": "Displays the status of your Duolingo account", 
 	"settings-schema": "org.gnome.shell.extensions.duolingostatus",
 	"uuid": "duolingostatus@david.bonnal.gmail.com"


### PR DESCRIPTION
Hi bo32,

I really like your duolingo gnome-shell extension. In this pull-request are 3 changes that I hope you like:
- Support gnome-shell 3.18 (which is now in Debian Sid; only needed changes in the metadata)
- use of https instead of http
- have the day change of the extension match the one on the duolingo website

If you have any questions or have comments on the patches, I would be glad to hear them. Anyhow, thanks for your nice work.

--Adam Schmalhofer
